### PR TITLE
Update name of CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ this repository and it will be installed to /etc/nymea-networkmanager.conf with 
 
 # Command line parameters
 
-    $ nymea-network-manager --help
+    $ nymea-networkmanager --help
     Usage:nymea-networkmanager [options]
     
     This daemon allows to configure a wifi network using a bluetooth low energy connection.


### PR DESCRIPTION
On my Raspbian Buster system, the CLI is named differently:

```
pi@raspberrypi:~ $ nymea-network-manager -d
-bash: nymea-network-manager: command not found
```